### PR TITLE
fix: consume rwasm halt reason mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2646,7 +2646,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3133,7 +3133,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3295,7 +3295,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4418,7 +4418,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4759,7 +4759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4926,7 +4926,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7408,7 +7408,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8431,7 +8431,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9698,7 +9698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9899,7 +9899,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11213,7 +11213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11285,7 +11285,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12147,7 +12147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12215,7 +12215,7 @@ dependencies = [
  "derive_more 2.1.1",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12250,7 +12250,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12890,7 +12890,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13097,7 +13097,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13116,7 +13116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14929,7 +14929,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15107,7 +15107,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,7 +3295,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4759,7 +4759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4926,7 +4926,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-build"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-codec"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "alloy-primitives",
  "byteorder",
@@ -5091,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-codec-derive"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "convert_case 0.6.0",
  "crypto-hashes",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-crypto"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -5117,7 +5117,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-evm"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",
@@ -5134,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-revm"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-runtime"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -5171,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-sdk"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
@@ -5189,7 +5189,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-sdk-derive"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "alloy-sol-macro-input",
  "crypto-hashes",
@@ -5203,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-sdk-derive-core"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "alloy-sol-macro-input",
  "anyhow",
@@ -5226,7 +5226,7 @@ dependencies = [
 [[package]]
 name = "fluentbase-types"
 version = "1.2.1"
-source = "git+https://github.com/fluentlabs-xyz/fluentbase?rev=f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f#f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f"
+source = "git+https://github.com/hedwig0x/fluentbase?branch=fix%2Fevm-wasm-exit-code-mapping-v1.3#8a522d930c205c47d4b21b011bae1476a4a65b89"
 dependencies = [
  "alloy-primitives",
  "bincode 2.0.1",
@@ -7408,7 +7408,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8781,7 +8781,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "19.0.0"
-source = "git+https://github.com/ethereum-optimism/optimism?rev=42f5117c2e7de0614cd3b96f274d0a3078f9701c#42f5117c2e7de0614cd3b96f274d0a3078f9701c"
+source = "git+https://github.com/hedwig0x/optimism?branch=fix%2Frwasm-halt-reason-op-revm#e90f1103ec78d40ca22bb83c967403dba3ad3ab1"
 dependencies = [
  "auto_impl",
  "revm",
@@ -9899,7 +9899,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10800,7 +10800,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10831,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -10844,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "auto_impl",
  "either",
@@ -10857,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "auto_impl",
  "either",
@@ -10912,7 +10912,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10924,7 +10924,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10948,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -11213,7 +11213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11285,7 +11285,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12890,13 +12890,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12923,7 +12923,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.3"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy-eips 2.0.1",
  "alloy-evm",
@@ -12942,7 +12942,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12960,7 +12960,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12971,7 +12971,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12998,7 +12998,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13018,7 +13018,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13029,7 +13029,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.1",
@@ -13060,7 +13060,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.6.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69#1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69"
+source = "git+https://github.com/hedwig0x/tempo?branch=fix%2Frwasm-halt-reason-tempo#3045b1e05a54269689d6c5228558af5eb5406adc"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -15107,7 +15107,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2646,7 +2646,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3133,7 +3133,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3295,7 +3295,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4418,7 +4418,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4759,7 +4759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4926,7 +4926,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7408,7 +7408,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8431,7 +8431,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9698,7 +9698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9899,7 +9899,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10800,7 +10800,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10831,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -10844,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "auto_impl",
  "either",
@@ -10857,7 +10857,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "auto_impl",
  "either",
@@ -10912,7 +10912,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10924,7 +10924,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10948,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#8aef81209a41753ee02eac0077286c9d498b2007"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason-v107#610349caede23b0fe78012efcd278bbfb859104a"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -11213,7 +11213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11285,7 +11285,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12147,7 +12147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12215,7 +12215,7 @@ dependencies = [
  "derive_more 2.1.1",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12250,7 +12250,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12890,7 +12890,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13097,7 +13097,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13116,7 +13116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14929,7 +14929,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15107,7 +15107,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -516,23 +516,23 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "554d20112eb014bd223d5
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo", default-features = false }
+tempo-primitives = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo", default-features = false }
+tempo-evm = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo", default-features = false }
+tempo-revm = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69" }
+tempo-contracts = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo" }
+tempo-precompiles = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo" }
 
 # Fluent
-fluentbase-build = { git = "https://github.com/fluentlabs-xyz/fluentbase", rev = "f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f" }
-fluentbase-revm = { git = "https://github.com/fluentlabs-xyz/fluentbase", rev = "f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f" }
-fluentbase-types = { git = "https://github.com/fluentlabs-xyz/fluentbase", rev = "f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f" }
-fluentbase-evm = { git = "https://github.com/fluentlabs-xyz/fluentbase", rev = "f7e7e187eb3d6ab476cbee7a039ca3e2dc567f4f" }
+fluentbase-build = { git = "https://github.com/hedwig0x/fluentbase", branch = "fix/evm-wasm-exit-code-mapping-v1.3" }
+fluentbase-revm = { git = "https://github.com/hedwig0x/fluentbase", branch = "fix/evm-wasm-exit-code-mapping-v1.3" }
+fluentbase-types = { git = "https://github.com/hedwig0x/fluentbase", branch = "fix/evm-wasm-exit-code-mapping-v1.3" }
+fluentbase-evm = { git = "https://github.com/hedwig0x/fluentbase", branch = "fix/evm-wasm-exit-code-mapping-v1.3" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -603,7 +603,7 @@ reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "
 reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "6b12498" }
 
 ## op-revm / op-alloy / alloy-op-evm
-op-revm = { git = "https://github.com/ethereum-optimism/optimism", rev = "42f5117c2e7de0614cd3b96f274d0a3078f9701c" }
+op-revm = { git = "https://github.com/hedwig0x/optimism", branch = "fix/rwasm-halt-reason-op-revm" }
 op-alloy-consensus = { git = "https://github.com/ethereum-optimism/optimism", rev = "42f5117c2e7de0614cd3b96f274d0a3078f9701c" }
 op-alloy-network = { git = "https://github.com/ethereum-optimism/optimism", rev = "42f5117c2e7de0614cd3b96f274d0a3078f9701c" }
 op-alloy-rpc-types = { git = "https://github.com/ethereum-optimism/optimism", rev = "42f5117c2e7de0614cd3b96f274d0a3078f9701c" }
@@ -614,9 +614,9 @@ alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", re
 # foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2f90eb86d4549fa15a8cc2d99bfc1039bc083977" }
 
 ## tempo — unify crates.io versions (pulled by mpp) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "1e5a82dff207e2cbd6cecdcfb8ff3cd2e39baa69" }
+tempo-primitives = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo" }
+tempo-alloy = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo" }
+tempo-contracts = { git = "https://github.com/hedwig0x/tempo", branch = "fix/rwasm-halt-reason-tempo" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
@@ -625,19 +625,37 @@ solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar
 solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 
 # --- gblend / fluentbase patches (enabled) ---
-#op-revm = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-bytecode = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-context = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-context-interface = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-database = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-database-interface = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-inspector = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-interpreter = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-primitives = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
-revm-state = {git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched"}
+revm = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-bytecode = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-context = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-context-interface = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-database = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-database-interface = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-inspector = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-interpreter = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-primitives = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-handler = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-precompile = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-state = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
 #alloy-evm = {git = "https://github.com/fluentlabs-xyz/alloy-rwasm", branch = "v26-patched"}
 #alloy-op-evm = {git = "https://github.com/fluentlabs-xyz/alloy-rwasm", branch = "v26-patched"}
+
+[patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
+revm = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-bytecode = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-context = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-context-interface = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-database = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-database-interface = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-handler = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-inspector = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-interpreter = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-precompile = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-primitives = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+revm-state = {git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason-v107"}
+
+[patch."https://github.com/ethereum-optimism/optimism"]
+op-revm = {git = "https://github.com/hedwig0x/optimism", branch = "fix/rwasm-halt-reason-op-revm"}
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/evm/core/src/evm/fluent.rs
+++ b/crates/evm/core/src/evm/fluent.rs
@@ -17,7 +17,8 @@ use core::{
 use alloy_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, Bytes};
 use fluentbase_revm::{
-    DefaultRwasm, RwasmBuilder, RwasmEvm, RwasmFrame, RwasmHandler, RwasmPrecompiles,
+    DefaultRwasm, RwasmBuilder, RwasmEvm, RwasmFrame, RwasmHaltReason, RwasmHandler,
+    RwasmPrecompiles,
     revm::{
         Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
         context::{
@@ -41,7 +42,7 @@ use foundry_fork_db::DatabaseError;
 use crate::{
     FoundryInspectorExt,
     backend::{DatabaseExt, JournaledState},
-    evm::{FoundryEvmFactory, NestedEvm},
+    evm::{FoundryEvmFactory, IntoInstructionResult, NestedEvm},
 };
 
 /// Type alias for the Fluent EVM context. Structurally identical to
@@ -121,7 +122,7 @@ where
     type DB = DB;
     type Tx = TxEnv;
     type Error = EVMError<DB::Error>;
-    type HaltReason = HaltReason;
+    type HaltReason = RwasmHaltReason;
     type Spec = SpecId;
     type BlockEnv = BlockEnv;
     type Precompiles = PRECOMPILE;
@@ -139,7 +140,10 @@ where
         self.cfg.chain_id
     }
 
-    fn transact_raw(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
+    fn transact_raw(
+        &mut self,
+        tx: Self::Tx,
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         if self.inspect { self.inner.inspect_tx(tx) } else { self.inner.transact(tx) }
     }
 
@@ -148,7 +152,7 @@ where
         caller: Address,
         contract: Address,
         data: Bytes,
-    ) -> Result<ResultAndState, Self::Error> {
+    ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         self.inner.system_call_with_caller(caller, contract, data)
     }
 
@@ -232,7 +236,7 @@ impl EvmFactory for FluentEvmFactory {
     type Context<DB: Database> = FluentEvmContext<DB>;
     type Tx = TxEnv;
     type Error<DBError: core::error::Error + Send + Sync + 'static> = EVMError<DBError>;
-    type HaltReason = HaltReason;
+    type HaltReason = RwasmHaltReason;
     type Spec = SpecId;
     type BlockEnv = BlockEnv;
     type Precompiles = PrecompilesMap;
@@ -327,7 +331,9 @@ where
     ) -> Result<ResultAndState<HaltReason>, EVMError<DatabaseError>> {
         self.inner.ctx_mut().set_tx(tx);
         let mut handler: FluentEvmHandler<'db, I> = RwasmHandler::default();
-        let result = handler.inspect_run(&mut self.inner)?;
+        let result = handler
+            .inspect_run(&mut self.inner)?
+            .map_haltreason(|h| h.into_instruction_result().into());
         Ok(ResultAndState::new(result, self.ctx().journaled_state.inner.state.clone()))
     }
 

--- a/crates/evm/core/src/evm/mod.rs
+++ b/crates/evm/core/src/evm/mod.rs
@@ -13,6 +13,7 @@ use alloy_network::{Ethereum, Network};
 use alloy_op_evm::OpEvmFactory;
 use alloy_primitives::{Address, Signature, U256};
 use alloy_rlp::Decodable;
+use fluentbase_revm::RwasmHaltReason;
 use foundry_common::{FoundryReceiptResponse, FoundryTransactionBuilder, fmt::UIfmt};
 use foundry_config::FromEvmVersion;
 use foundry_fork_db::{DatabaseError, ForkBlockEnv};
@@ -272,6 +273,30 @@ impl IntoInstructionResult for TempoHaltReason {
         match self {
             Self::Ethereum(eth) => eth.into(),
             _ => InstructionResult::PrecompileError,
+        }
+    }
+}
+
+impl IntoInstructionResult for RwasmHaltReason {
+    fn into_instruction_result(self) -> InstructionResult {
+        match self {
+            Self::Base(eth) => eth.into(),
+            Self::RootCallOnly => InstructionResult::RootCallOnly,
+            Self::MalformedBuiltinParams => InstructionResult::MalformedBuiltinParams,
+            Self::CallDepthOverflow => InstructionResult::CallDepthOverflow,
+            Self::NonNegativeExitCode => InstructionResult::NonNegativeExitCode,
+            Self::UnknownError => InstructionResult::UnknownError,
+            Self::InputOutputOutOfBounds => InstructionResult::InputOutputOutOfBounds,
+            Self::UnreachableCodeReached => InstructionResult::UnreachableCodeReached,
+            Self::MemoryOutOfBounds => InstructionResult::MemoryOutOfBounds,
+            Self::TableOutOfBounds => InstructionResult::TableOutOfBounds,
+            Self::IndirectCallToNull => InstructionResult::IndirectCallToNull,
+            Self::IntegerDivisionByZero => InstructionResult::IntegerDivisionByZero,
+            Self::IntegerOverflow => InstructionResult::IntegerOverflow,
+            Self::BadConversionToInteger => InstructionResult::BadConversionToInteger,
+            Self::BadSignature => InstructionResult::BadSignature,
+            Self::OutOfFuel => InstructionResult::OutOfFuel,
+            Self::UnknownExternalFunction => InstructionResult::UnknownExternalFunction,
         }
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,8 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2024-0370 proc-macro-error is pulled by temporary Fluentbase dependency
+    "RUSTSEC-2024-0370",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
     "RUSTSEC-2025-0141",
     # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand is unsound with a custom logger
@@ -108,10 +110,15 @@ allow-git = [
     "https://github.com/rust-cli/rexpect",
     # Tempo
     "https://github.com/tempoxyz/tempo",
+    "https://github.com/hedwig0x/tempo",
     "https://github.com/tempoxyz/mpp-rs",
     # Transitive dependency of Tempo
     "https://github.com/paradigmxyz/reth",
     "https://github.com/paradigmxyz/reth-core",
     # Temporary: upstream OP crates until release is published.
     "https://github.com/ethereum-optimism/optimism",
+    "https://github.com/hedwig0x/optimism",
+    # Temporary FLU-27 dependency branches.
+    "https://github.com/hedwig0x/fluentbase",
+    "https://github.com/hedwig0x/revm-rwasm.git",
 ]


### PR DESCRIPTION
## Summary
- update Fluentbase dependencies to the FLU-27 exit-code mapping branch
- route gblend Fluent EVM halt reasons through `RwasmHaltReason` and convert nested EVM halts back to Foundry `HaltReason`
- patch dependent Optimism and Tempo git deps with the matching halt conversion required by the narrowed revm-rwasm API

## Checks
- `cargo fetch --locked`
- `cargo +nightly check --locked -p foundry-evm-core`